### PR TITLE
Fix get_weight_src from dark/darknet.py

### DIFF
--- a/darkflow/dark/darknet.py
+++ b/darkflow/dark/darknet.py
@@ -37,7 +37,7 @@ class Darknet(object):
             self.src_bin = FLAGS.model
         if FLAGS.binary != "":
             self.src_bin = FLAGS.binary
-        if FLAGS.load != "":
+        if FLAGS.load != "" and type(FLAGS.load) is not int:
             self.src_bin = FLAGS.load
         if self.src_bin != "" and os.path.splitext(self.src_bin)[1] == "":
             self.src_bin = self.src_bin + self._EXT

--- a/darkflow/dark/darknet.py
+++ b/darkflow/dark/darknet.py
@@ -35,6 +35,8 @@ class Darknet(object):
         self.src_bin = ""
         if FLAGS.model != "":
             self.src_bin = FLAGS.model
+        if FLAGS.binary != "":
+            self.src_bin = FLAGS.binary
         if FLAGS.load != "":
             self.src_bin = FLAGS.load
         if self.src_bin != "" and os.path.splitext(self.src_bin)[1] == "":

--- a/darkflow/dark/darknet.py
+++ b/darkflow/dark/darknet.py
@@ -32,21 +32,27 @@ class Darknet(object):
         source binary and what is its config.
         can be: None, FLAGS.model, or some other
         """
-        self.src_bin = FLAGS.model + self._EXT
-        self.src_bin = FLAGS.binary + self.src_bin
-        self.src_bin = os.path.abspath(self.src_bin)
+        self.src_bin = ""
+        if FLAGS.model != "":
+            self.src_bin = FLAGS.model
+        if FLAGS.load != "":
+            self.src_bin = FLAGS.load
+        if self.src_bin != "" and os.path.splitext(self.src_bin)[1] == "":
+            self.src_bin = self.src_bin + self._EXT
+        if not os.path.isabs(self.src_bin):
+            self.src_bin = os.path.abspath(self.src_bin)
         exist = os.path.isfile(self.src_bin)
 
         if FLAGS.load == str(): FLAGS.load = int()
+
         if type(FLAGS.load) is int:
             self.src_cfg = FLAGS.model
             if FLAGS.load: self.src_bin = None
             elif not exist: self.src_bin = None
         else:
-            assert os.path.isfile(FLAGS.load), \
+            assert os.path.isfile(self.src_bin), \
             '{} not found'.format(FLAGS.load)
-            self.src_bin = FLAGS.load
-            name = loader.model_name(FLAGS.load)
+            name = loader.model_name(os.path.basename(self.src_bin))
             cfg_path = os.path.join(FLAGS.config, name + '.cfg')
             if not os.path.isfile(cfg_path):
                 warnings.warn(


### PR DESCRIPTION
There are two ways in which you call the `get_weight_src`:
- First is by passing the --binary flag with a file
- Second one is by passing the --load flag with a file
This PR makes get_weight_src read from any of them, avoid adding the extension when not needed, and doesn't use ./bin as default unless --load is not set.