### PR TITLE
Update darknet.py

### DIFF
--- a/darkflow/dark/darknet.py
+++ b/darkflow/dark/darknet.py
@@ -47,7 +47,7 @@ class Darknet(object):
             '{} not found'.format(FLAGS.load)
             self.src_bin = FLAGS.load
             name = loader.model_name(FLAGS.load)
-            cfg_path = os.path.join(FLAGS.config, name + '.cfg')
+            cfg_path = os.path.join(FLAGS.config)
             if not os.path.isfile(cfg_path):
                 warnings.warn(
                     '{} not found, use {} instead'.format(


### PR DESCRIPTION
Due to this issue :
Parsing yolov2.cfg
/content/darkflow/darkflow/dark/darknet.py:54: UserWarning: ./cfg/yolov2.cfg not found, use yolov2.cfg instead
  cfg_path, FLAGS.model))
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-60-63e160b4ff13> in <module>()
      4  'threshold': 0.3
      5 }
----> 6 tfnet = TFNet(options)

4 frames
/content/darkflow/darkflow/utils/process.py in parser(model)
     27                 if '[' in line:
     28                         if layer != dict():
---> 29                                 if layer['type'] == '[net]':
     30                                         h = layer['height']
     31                                         w = layer['width']

KeyError: 'type'